### PR TITLE
Update 'Submit a Feed' URL in ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## NEW FEEDS:
 
-To submit **new** feeds, visit [Submit a Feed](https://transitfeeds.com/submit).
+To submit **new** feeds, visit [Submit a Feed](https://openmobilitydata.org/submit).
 
 Note that if you click on **Submit a Feed** on a location or provider details page, the location and provider will be automatically populated.
 


### PR DESCRIPTION
Change URL for 'Submit a Feed' from https://transitfeeds.com/submit to https://openmobilitydata.org/submit. The current URL seems to have caused issues with ease of submitting new feeds from this repo ([see #520](https://github.com/OpenMobilityData/OpenMobilityData-Public/issues/520#issuecomment-727146083)).

The transitfeeds.com/submit URL will always return a 401. The current behavior is: you sign in with Github from the transitfeeds.com link, then you are redirected to openmobilitydata.org and authenticated there. If you then click the https://transitfeeds.com/submit link again, you will not be authenticated and see a 401 again.

Thanks,
Will